### PR TITLE
docs: Update Mac GN Universal Binary information

### DIFF
--- a/cn/ten_framework/dependencies.md
+++ b/cn/ten_framework/dependencies.md
@@ -22,7 +22,6 @@ Commit ID
 
 从[Gn仓库](https://gn.googlesource.com/gn)clone编译。
 
-
 ## Google ninja
 
 版本：1.12.1

--- a/cn/ten_framework/dependencies.md
+++ b/cn/ten_framework/dependencies.md
@@ -10,11 +10,18 @@ TEN 框架利用了多个第三方库。有些专门用于测试，而另一些�
 | -------- | ----- | -------------------------------------------- |
 | Linux    | x64   | BzX0zkfwFeUn9MaDVqm6FugmTIy-hFpgNUx43O1fN00C |
 | Linux    | arm64 | rT_12w1Iv6ug8CJ4j0VQekA0qTDq6CwoAqGWasIKFcEC |
-| Mac      | x64   | B31qpTXmBZpBHIdUtEFogC24WDCQ9W7qAS0d1eSxoZgC |
-| Mac      | arm64 | 5dcmC12_T9JLydmhjTjySyTC7FiYd75j-tyHVokWaFEC |
 | Win      | x64   | 1QlqF0FPVt82ba5f48HxHpv5xPqOmyaThoR3TicuJ8QC |
 
 直接从 [Google GN 网页](https://chrome-infra-packages.appspot.com/p/gn/gn/) 下载。
+
+Commit ID
+
+| 操作系统 | 架构      | Commit ID                                |
+| -------- | --------- | ---------------------------------------- |
+| Mac      | universal | 18602f6cf1168cf78302024043edc02e8bad2ffb |
+
+从[Gn仓库](https://gn.googlesource.com/gn)clone编译。
+
 
 ## Google ninja
 

--- a/en/ten_framework/dependencies.md
+++ b/en/ten_framework/dependencies.md
@@ -22,7 +22,6 @@ Commit ID
 
 Clone and build from the [Gn repository](https://gn.googlesource.com/gn).
 
-
 ## Google ninja
 
 Version: 1.12.1

--- a/en/ten_framework/dependencies.md
+++ b/en/ten_framework/dependencies.md
@@ -10,11 +10,18 @@ Instance ID
 |----|------|-------------|
 |Linux|x64|BzX0zkfwFeUn9MaDVqm6FugmTIy-hFpgNUx43O1fN00C|
 |Linux|arm64|rT_12w1Iv6ug8CJ4j0VQekA0qTDq6CwoAqGWasIKFcEC|
-|Mac|x64|B31qpTXmBZpBHIdUtEFogC24WDCQ9W7qAS0d1eSxoZgC|
-|Mac|arm64|5dcmC12_T9JLydmhjTjySyTC7FiYd75j-tyHVokWaFEC|
 |Win|x64|1QlqF0FPVt82ba5f48HxHpv5xPqOmyaThoR3TicuJ8QC|
 
 Download directly from [Google GN webpage](https://chrome-infra-packages.appspot.com/p/gn/gn/).
+
+Commit ID
+
+| OS  | Arch      | Commit ID                                |
+| --- | --------- | ---------------------------------------- |
+| Mac | universal | 18602f6cf1168cf78302024043edc02e8bad2ffb |
+
+Clone and build from the [Gn repository](https://gn.googlesource.com/gn).
+
 
 ## Google ninja
 


### PR DESCRIPTION
- Add details for self-compiled Mac Universal binary from official repository
- Include commit ID (18602f6cf1168cf78302024043edc02e8bad2ffb) for version tracking
- Clarify compilation source information to distinguish