### PR TITLE
docs: apple silicon build command update

### DIFF
--- a/en/ten_agent/deploy_ten_agent/deploy_agent_service.md
+++ b/en/ten_agent/deploy_ten_agent/deploy_agent_service.md
@@ -10,6 +10,12 @@ The Dockerfile has been prepared in project root folder. You can build the docke
 docker build -t ten-agent-server .
 ```
 
+For Apple Silicon, use the following command:
+
+```shell
+docker build -t ten-agent-server . --platform linux/amd64
+```
+
 In case you are using `demo` or `experimental` folder, you can build the docker image by running the following command:
 
 ```shell


### PR DESCRIPTION
fix for build issue:
- InvalidBaseImagePlatform: Base image [ghcr.io/ten-framework/ten_agent_build:0.4.10](http://ghcr.io/ten-framework/ten_agent_build:0.4.10) was pulled with platform "linux/amd64", expected "linux/arm64" for current build (line 1)

